### PR TITLE
feat: cli order command accepts "buy", "sell" order direction

### DIFF
--- a/x/liquidity/client/cli/tx.go
+++ b/x/liquidity/client/cli/tx.go
@@ -206,16 +206,18 @@ func NewLimitOrderCmd() *cobra.Command {
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Make a limit order.
 Example:
-$ %s tx %s limit-order 1 ORDER_DIRECTION_BUY 10000usquad uatom 1.0 10000 10s --from mykey
+$ %s tx %s limit-order 1 buy 5000usquad uatom 0.5 10000 10s --from mykey
+$ %s tx %s limit-order 1 s 10000uatom usquad 2.0 10000 10s --from mykey
 
 [pair-id]: pair id to swap with
-[direction]: order direction (one of: ORDER_DIRECTION_BUY,ORDER_DIRECTION_SELL)
+[direction]: order direction (one of: buy,b,sell,s)
 [offer-coin]: the amount of offer coin to swap
 [demand-coin-denom]: the denom to exchange with the offer coin
 [price]: the limit order price for the swap; the exchange ratio is X/Y where X is the amount of quote coin and Y is the amount of base coin
 [base-coin-amount]: the amount of base coin to buy or sell
 [order-lifespan]: the time duration that the order lives until it is expired; valid time units are "ns", "us", "ms", "s", "m", and "h" 
 `,
+				version.AppName, types.ModuleName,
 				version.AppName, types.ModuleName,
 			),
 		),
@@ -230,13 +232,9 @@ $ %s tx %s limit-order 1 ORDER_DIRECTION_BUY 10000usquad uatom 1.0 10000 10s --f
 				return fmt.Errorf("parse pair id: %w", err)
 			}
 
-			rawDir, ok := types.OrderDirection_value[args[1]]
-			if !ok {
-				return fmt.Errorf("unknown order direction: %s", args[1])
-			}
-			dir := types.OrderDirection(rawDir)
-			if dir != types.OrderDirectionBuy && dir != types.OrderDirectionSell {
-				return fmt.Errorf("invalid order direction: %s", dir)
+			dir, err := parseOrderDirection(args[1])
+			if err != nil {
+				return fmt.Errorf("parse order direction: %w", err)
 			}
 
 			offerCoin, err := sdk.ParseCoinNormalized(args[2])
@@ -292,15 +290,17 @@ func NewMarketOrderCmd() *cobra.Command {
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Make a market order.
 Example:
-$ %s tx %s market-order 1 ORDER_DIRECTION_BUY 10000usquad uatom 10000 10s --from mykey
+$ %s tx %s market-order 1 buy 5000usquad uatom 10000 10s --from mykey
+$ %s tx %s market-order 1 s 10000uatom usquad 10000 10s --from mykey
 
 [pair-id]: pair id to swap with
-[direction]: order direction (one of: ORDER_DIRECTION_BUY,ORDER_DIRECTION_SELL)
+[direction]: order direction (one of: buy,b,sell,s)
 [offer-coin]: the amount of offer coin to swap
 [demand-coin-denom]: the denom to exchange with the offer coin
 [base-coin-amount]: the amount of base coin to buy or sell
 [order-lifespan]: the time duration that the order lives until it is expired; valid time units are "ns", "us", "ms", "s", "m", and "h" 
 `,
+				version.AppName, types.ModuleName,
 				version.AppName, types.ModuleName,
 			),
 		),
@@ -315,13 +315,9 @@ $ %s tx %s market-order 1 ORDER_DIRECTION_BUY 10000usquad uatom 10000 10s --from
 				return fmt.Errorf("parse pair id: %w", err)
 			}
 
-			rawDir, ok := types.OrderDirection_value[args[1]]
-			if !ok {
-				return fmt.Errorf("unknown order direction: %s", args[1])
-			}
-			dir := types.OrderDirection(rawDir)
-			if dir != types.OrderDirectionBuy && dir != types.OrderDirectionSell {
-				return fmt.Errorf("invalid order direction: %s", dir)
+			dir, err := parseOrderDirection(args[1])
+			if err != nil {
+				return fmt.Errorf("parse order direction: %w", err)
 			}
 
 			offerCoin, err := sdk.ParseCoinNormalized(args[2])

--- a/x/liquidity/client/cli/util.go
+++ b/x/liquidity/client/cli/util.go
@@ -1,5 +1,12 @@
 package cli
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmosquad-labs/squad/x/liquidity/types"
+)
+
 // excConditions returns true when exactly one condition is true.
 func excConditions(conditions ...bool) bool {
 	cnt := 0
@@ -9,4 +16,16 @@ func excConditions(conditions ...bool) bool {
 		}
 	}
 	return cnt == 1
+}
+
+// parseOrderDirection parses order direction string and returns
+// types.OrderDirection.
+func parseOrderDirection(s string) (types.OrderDirection, error) {
+	switch strings.ToLower(s) {
+	case "buy", "b":
+		return types.OrderDirectionBuy, nil
+	case "sell", "s":
+		return types.OrderDirectionSell, nil
+	}
+	return 0, fmt.Errorf("invalid order direction: %s", s)
 }


### PR DESCRIPTION
## Description

Instead of specifying either `ORDER_DIRECTION_BUY` or `ORDER_DIRECTION_SELL` in cli parameters, cli now accepts these 4 strings as an order direction:
- `buy`
- `b`(alias for buy)
- `sell`
- `s`(alias for sell)