### PR TITLE
Fix offer coin refund

### DIFF
--- a/x/liquidity/keeper/batch.go
+++ b/x/liquidity/keeper/batch.go
@@ -17,9 +17,9 @@ func (k Keeper) ExecuteRequests(ctx sdk.Context) {
 	}); err != nil {
 		panic(err)
 	}
-	if err := k.IterateAllOrders(ctx, func(req types.Order) (stop bool, err error) {
-		if req.Status.CanBeExpired() && req.ExpiredAt(ctx.BlockTime()) {
-			if err := k.FinishOrder(ctx, req, types.OrderStatusExpired); err != nil {
+	if err := k.IterateAllOrders(ctx, func(order types.Order) (stop bool, err error) {
+		if order.Status.CanBeExpired() && order.ExpiredAt(ctx.BlockTime()) {
+			if err := k.FinishOrder(ctx, order, types.OrderStatusExpired); err != nil {
 				return false, err
 			}
 		}

--- a/x/liquidity/keeper/batch_test.go
+++ b/x/liquidity/keeper/batch_test.go
@@ -1,32 +1,46 @@
 package keeper_test
 
 import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	utils "github.com/cosmosquad-labs/squad/types"
+	"github.com/cosmosquad-labs/squad/x/liquidity"
+	"github.com/cosmosquad-labs/squad/x/liquidity/types"
 
 	_ "github.com/stretchr/testify/suite"
 )
 
-func (s *KeeperTestSuite) TestDepositWithdraw() {
-	k, ctx := s.keeper, s.ctx
+func (s *KeeperTestSuite) TestOrderExpiration() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
 
-	params := k.GetParams(ctx)
+	s.ctx = s.ctx.WithBlockTime(utils.ParseTime("2022-03-01T12:00:00Z"))
+	order := s.limitOrder(s.addr(1), pair.Id, types.OrderDirectionSell, utils.ParseDec("1.0"), sdk.NewInt(10000), 10*time.Second, true)
+	liquidity.EndBlocker(s.ctx, s.keeper)
 
-	// Create a normal pool
-	creator := s.addr(0)
-	s.createPair(creator, "denom1", "denom2", true)
-	s.createPool(creator, 1, utils.ParseCoins("1000000denom1,1000000denom2"), true)
+	s.ctx = s.ctx.WithBlockTime(utils.ParseTime("2022-03-01T12:00:06Z"))
+	liquidity.BeginBlocker(s.ctx, s.keeper)
+	order, found := s.keeper.GetOrder(s.ctx, order.PairId, order.Id)
+	s.Require().True(found) // The order is not yet deleted.
+	// A buy order comes in.
+	s.limitOrder(s.addr(2), pair.Id, types.OrderDirectionBuy, utils.ParseDec("1.0"), sdk.NewInt(5000), 0, true)
+	liquidity.EndBlocker(s.ctx, s.keeper)
 
-	pool, found := k.GetPool(ctx, 1)
+	s.ctx = s.ctx.WithBlockTime(utils.ParseTime("2022-03-01T12:00:12Z"))
+	liquidity.BeginBlocker(s.ctx, s.keeper)
+	order, found = s.keeper.GetOrder(s.ctx, order.PairId, order.Id)
 	s.Require().True(found)
-	s.Require().Equal(params.MinInitialPoolCoinSupply, s.getBalance(creator, pool.PoolCoinDenom).Amount)
+	s.Require().Equal(types.OrderStatusPartiallyMatched, order.Status)
+	// Another buy order comes in, but this time the first order has been expired,
+	// so there is no match.
+	s.limitOrder(s.addr(3), pair.Id, types.OrderDirectionBuy, utils.ParseDec("1.0"), sdk.NewInt(5000), 0, true)
+	liquidity.EndBlocker(s.ctx, s.keeper)
+	order, _ = s.keeper.GetOrder(s.ctx, order.PairId, order.Id)
+	s.Require().Equal(types.OrderStatusExpired, order.Status)
+	s.Require().True(intEq(sdk.NewInt(5000), order.OpenAmount))
 
-	// A depositor makes a deposit
-	depositor := s.addr(1)
-	s.deposit(depositor, pool.Id, utils.ParseCoins("500000denom1,500000denom2"), true)
-	s.nextBlock()
-
-	// The depositor withdraws pool coin
-	poolCoin := s.getBalance(depositor, pool.PoolCoinDenom)
-	s.withdraw(depositor, pool.Id, poolCoin)
-	s.nextBlock()
+	liquidity.BeginBlocker(s.ctx, s.keeper)
+	_, found = s.keeper.GetOrder(s.ctx, order.PairId, order.Id)
+	s.Require().False(found) // The order is gone.
 }

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -64,7 +64,7 @@ func (k Keeper) ValidateMsgLimitOrder(ctx sdk.Context, msg *types.MsgLimitOrder)
 					msg.OfferCoin.Denom, msg.DemandCoinDenom, pair.BaseCoinDenom, pair.QuoteCoinDenom)
 		}
 		price = amm.PriceToUpTick(msg.Price, int(params.TickPrecision))
-		offerCoin = msg.OfferCoin
+		offerCoin = sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount)
 		if msg.OfferCoin.Amount.LT(msg.Amount) {
 			return sdk.Coin{}, sdk.Dec{}, sdkerrors.Wrapf(
 				types.ErrInsufficientOfferCoin, "%s is smaller than %s", msg.OfferCoin, sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount))
@@ -155,7 +155,7 @@ func (k Keeper) ValidateMsgMarketOrder(ctx sdk.Context, msg *types.MsgMarketOrde
 					msg.OfferCoin.Denom, msg.DemandCoinDenom, pair.BaseCoinDenom, pair.QuoteCoinDenom)
 		}
 		price = amm.PriceToUpTick(lastPrice.Mul(sdk.OneDec().Sub(params.MaxPriceLimitRatio)), int(params.TickPrecision))
-		offerCoin = msg.OfferCoin
+		offerCoin = sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount)
 		if msg.OfferCoin.Amount.LT(msg.Amount) {
 			return sdk.Coin{}, sdk.Dec{}, sdkerrors.Wrapf(
 				types.ErrInsufficientOfferCoin, "%s is smaller than %s", msg.OfferCoin, sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount))


### PR DESCRIPTION
## Description

Currently there is a bug in offer coin refund, which happens when the offer coin amount is greater than the order amount in sell orders.
This PR fixes the bug and adds related tests.