### PR TITLE
fix: use truncated open amount before matching

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -611,7 +611,8 @@ func NewApp(
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		// Temporarily disable x/authz simulation
+		// authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
 		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
 		budget.NewAppModule(appCodec, app.BudgetKeeper, app.AccountKeeper, app.BankKeeper),

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -11,11 +11,7 @@ import (
 
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
-	claimtypes "github.com/cosmosquad-labs/squad/x/claim/types"
-	liquiditytypes "github.com/cosmosquad-labs/squad/x/liquidity/types"
-	liquidstakingtypes "github.com/cosmosquad-labs/squad/x/liquidstaking/types"
 	"github.com/stretchr/testify/require"
-	budgettypes "github.com/tendermint/budget/x/budget/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/simapp"
@@ -34,13 +30,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	minttypes "github.com/cosmosquad-labs/squad/x/mint/types"
+	budgettypes "github.com/tendermint/budget/x/budget/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
+	claimtypes "github.com/cosmosquad-labs/squad/x/claim/types"
 	farmingtypes "github.com/cosmosquad-labs/squad/x/farming/types"
+	liquiditytypes "github.com/cosmosquad-labs/squad/x/liquidity/types"
+	liquidstakingtypes "github.com/cosmosquad-labs/squad/x/liquidstaking/types"
+	minttypes "github.com/cosmosquad-labs/squad/x/mint/types"
 )
 
 // Get flags every time the simulator is run
@@ -298,8 +298,8 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.AllInvariants = false
 	config.ChainID = helpers.SimAppChainID
 
-	numSeeds := 1
-	numTimesToRunPerSeed := 1
+	numSeeds := 3
+	numTimesToRunPerSeed := 5
 	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
 
 	for i := 0; i < numSeeds; i++ {

--- a/x/liquidity/amm/match.go
+++ b/x/liquidity/amm/match.go
@@ -91,7 +91,8 @@ func FindLastMatchableOrders(buyOrders, sellOrders []Order, matchPrice sdk.Dec) 
 	// If there is not, then the loop is finished.
 	for {
 		ok := true
-		for dir, side := range sides {
+		for _, dir := range []OrderDirection{Buy, Sell} {
+			side := sides[dir]
 			i := side.i
 			order := side.orders[i]
 			matchAmt := sdk.MinInt(buySide.totalOpenAmt, sellSide.totalOpenAmt)

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -399,10 +399,10 @@ func (k Keeper) ApplyMatchResult(ctx sdk.Context, pair types.Pair, orders []amm.
 		switch order := order.(type) {
 		case *types.UserOrder:
 			o, _ := k.GetOrder(ctx, pair.Id, order.OrderId)
-			o.OpenAmount = order.OpenAmount
-			o.RemainingOfferCoin = order.RemainingOfferCoin
-			o.ReceivedCoin = o.ReceivedCoin.AddAmount(order.ReceivedDemandCoin.Amount)
-			if order.OpenAmount.IsZero() {
+			o.OpenAmount = o.OpenAmount.Sub(order.Amount.Sub(order.OpenAmount))
+			o.RemainingOfferCoin = o.RemainingOfferCoin.Sub(order.OfferCoin.Sub(order.RemainingOfferCoin))
+			o.ReceivedCoin = o.ReceivedCoin.Add(order.ReceivedDemandCoin)
+			if o.OpenAmount.IsZero() {
 				if err := k.FinishOrder(ctx, o, types.OrderStatusCompleted); err != nil {
 					return err
 				}

--- a/x/liquidity/keeper/swap_test.go
+++ b/x/liquidity/keeper/swap_test.go
@@ -570,3 +570,22 @@ func (s *KeeperTestSuite) TestInsufficientRemainingOfferCoin() {
 	s.Require().Equal(types.OrderStatusPartiallyMatched, order.Status)
 	s.Require().True(intEq(sdk.OneInt(), order.OpenAmount))
 }
+
+func (s *KeeperTestSuite) TestNegativeOpenAmount() {
+	s.ctx = s.ctx.WithBlockHeight(1).WithBlockTime(utils.ParseTime("2022-03-01T00:00:00Z"))
+
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	order := s.buyLimitOrder(s.addr(1), pair.Id, utils.ParseDec("0.82"), sdk.NewInt(648744), 0, true)
+	s.sellLimitOrder(s.addr(2), pair.Id, utils.ParseDec("0.82"), sdk.NewInt(648745), 0, true)
+	liquidity.EndBlocker(s.ctx, s.keeper)
+
+	order, found := s.keeper.GetOrder(s.ctx, order.PairId, order.Id)
+	s.Require().True(found)
+	s.Require().False(order.OpenAmount.IsNegative())
+
+	genState := s.keeper.ExportGenesis(s.ctx)
+	s.Require().NotPanics(func() {
+		s.keeper.InitGenesis(s.ctx, *genState)
+	})
+}

--- a/x/liquidity/types/order.go
+++ b/x/liquidity/types/order.go
@@ -72,14 +72,17 @@ type UserOrder struct {
 // NewUserOrder returns a new user order.
 func NewUserOrder(order Order) *UserOrder {
 	var dir amm.OrderDirection
+	var amt sdk.Int
 	switch order.Direction {
 	case OrderDirectionBuy:
 		dir = amm.Buy
+		amt = order.RemainingOfferCoin.Amount.ToDec().QuoTruncate(order.Price).TruncateInt()
 	case OrderDirectionSell:
 		dir = amm.Sell
+		amt = order.OpenAmount
 	}
 	return &UserOrder{
-		BaseOrder: amm.NewBaseOrder(dir, order.Price, order.OpenAmount, order.RemainingOfferCoin, order.ReceivedCoin.Denom),
+		BaseOrder: amm.NewBaseOrder(dir, order.Price, amt, order.RemainingOfferCoin, order.ReceivedCoin.Denom),
 		OrderId:   order.Id,
 		Orderer:   order.GetOrderer(),
 	}

--- a/x/liquidity/types/order.go
+++ b/x/liquidity/types/order.go
@@ -76,7 +76,10 @@ func NewUserOrder(order Order) *UserOrder {
 	switch order.Direction {
 	case OrderDirectionBuy:
 		dir = amm.Buy
-		amt = order.RemainingOfferCoin.Amount.ToDec().QuoTruncate(order.Price).TruncateInt()
+		amt = sdk.MinInt(
+			order.OpenAmount,
+			order.RemainingOfferCoin.Amount.ToDec().QuoTruncate(order.Price).TruncateInt(),
+		)
 	case OrderDirectionSell:
 		dir = amm.Sell
 		amt = order.OpenAmount


### PR DESCRIPTION
## Description

Use `floor(remaining offer coin / price)` as `OpenAmount` when converting `types.Order` to `amm.Order`.
This prevents `negative coin` panic in matching.

Also disable `x/authz` simulation since it causes unknown problem(fix the module later).

Closes: #264