### PR TITLE
fix: liquidstaking tally map iteration to deterministic

### DIFF
--- a/x/liquidstaking/simulation/proposals.go
+++ b/x/liquidstaking/simulation/proposals.go
@@ -174,12 +174,10 @@ func SimulateTallyWithLiquidStaking(ak types.AccountKeeper, bk types.BankKeeper,
 					targetProposal.DepositEndTime = ctx.BlockTime()
 					targetProposal.VotingEndTime = ctx.BlockTime()
 					ctx = ctx.WithBlockTime(ctx.BlockTime().Add(5 * time.Second))
-					_, _, res := gk.Tally(ctx, *targetProposal)
-
-					// set tally result to check deterministic
+					cachedCtx, _ := ctx.CacheContext()
+					_, _, res := gk.Tally(cachedCtx, *targetProposal)
 					targetProposal.FinalTallyResult = res
-					gk.SetProposal(ctx, *targetProposal)
-					fmt.Println("## SimulateTallyWithLiquidStaking", res)
+					fmt.Println("## SimulateTallyWithLiquidStaking", res, targetProposal.ProposalId)
 					break
 				}
 			}

--- a/x/liquidstaking/simulation/proposals.go
+++ b/x/liquidstaking/simulation/proposals.go
@@ -3,6 +3,7 @@ package simulation
 import (
 	"fmt"
 	"math/rand"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -170,7 +171,14 @@ func SimulateTallyWithLiquidStaking(ak types.AccountKeeper, bk types.BankKeeper,
 					if err != nil {
 						panic(err)
 					}
+					targetProposal.DepositEndTime = ctx.BlockTime()
+					targetProposal.VotingEndTime = ctx.BlockTime()
+					ctx = ctx.WithBlockTime(ctx.BlockTime().Add(5 * time.Second))
 					_, _, res := gk.Tally(ctx, *targetProposal)
+
+					// set tally result to check deterministic
+					targetProposal.FinalTallyResult = res
+					gk.SetProposal(ctx, *targetProposal)
 					fmt.Println("## SimulateTallyWithLiquidStaking", res)
 					break
 				}

--- a/x/liquidstaking/types/expected_keepers.go
+++ b/x/liquidstaking/types/expected_keepers.go
@@ -83,6 +83,7 @@ type GovKeeper interface {
 	GetVotes(ctx sdk.Context, proposalID uint64) (votes govtypes.Votes)
 	GetVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) (vote govtypes.Vote, found bool)
 	GetProposal(ctx sdk.Context, proposalID uint64) (govtypes.Proposal, bool)
+	SetProposal(ctx sdk.Context, proposal govtypes.Proposal)
 	GetProposals(ctx sdk.Context) (proposals govtypes.Proposals)
 	AddVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress, options govtypes.WeightedVoteOptions) error
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Since iteration order of map types is not deterministic, modify to use the deterministic list when iterating

## Tasks
- `voterBalanceByDenom`

There are other map Iterating logics in the file, but in the modified part, there is room for different results such as GasConsumed according to kv seeking by calling `k.TokenSharePerPoolCoin`, but other logics are not modified because they are type levels that only calculate.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
