### PR TITLE
fix: set indexes only once

### DIFF
--- a/x/liquidity/keeper/genesis.go
+++ b/x/liquidity/keeper/genesis.go
@@ -17,18 +17,26 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	k.SetLastPoolId(ctx, genState.LastPoolId)
 	for _, pair := range genState.Pairs {
 		k.SetPair(ctx, pair)
+		k.SetPairIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
+		k.SetPairLookupIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
+		k.SetPairLookupIndex(ctx, pair.QuoteCoinDenom, pair.BaseCoinDenom, pair.Id)
 	}
 	for _, pool := range genState.Pools {
 		k.SetPool(ctx, pool)
+		k.SetPoolByReserveIndex(ctx, pool)
+		k.SetPoolsByPairIndex(ctx, pool)
 	}
 	for _, req := range genState.DepositRequests {
 		k.SetDepositRequest(ctx, req)
+		k.SetDepositRequestIndex(ctx, req)
 	}
 	for _, req := range genState.WithdrawRequests {
 		k.SetWithdrawRequest(ctx, req)
+		k.SetWithdrawRequestIndex(ctx, req)
 	}
 	for _, order := range genState.Orders {
 		k.SetOrder(ctx, order)
+		k.SetOrderIndex(ctx, order)
 	}
 }
 

--- a/x/liquidity/keeper/genesis_test.go
+++ b/x/liquidity/keeper/genesis_test.go
@@ -1,7 +1,12 @@
 package keeper_test
 
 import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	utils "github.com/cosmosquad-labs/squad/types"
+	"github.com/cosmosquad-labs/squad/x/liquidity"
 	"github.com/cosmosquad-labs/squad/x/liquidity/types"
 )
 
@@ -73,4 +78,90 @@ func (s *KeeperTestSuite) TestImportExportGenesisEmpty() {
 	genState3 := k.ExportGenesis(ctx)
 	s.Require().Equal(*genState, genState2)
 	s.Require().Equal(genState2, *genState3)
+}
+
+func (s *KeeperTestSuite) TestIndexesAfterImport() {
+	s.ctx = s.ctx.WithBlockHeight(1).WithBlockTime(utils.ParseTime("2022-03-01T00:00:00Z"))
+
+	pair1 := s.createPair(s.addr(0), "denom1", "denom2", true)
+	pair2 := s.createPair(s.addr(1), "denom2", "denom3", true)
+
+	pool1 := s.createPool(s.addr(2), pair1.Id, utils.ParseCoins("1000000denom1,1000000denom2"), true)
+	pool2 := s.createPool(s.addr(3), pair2.Id, utils.ParseCoins("1000000denom2,1000000denom3"), true)
+
+	s.deposit(s.addr(4), pool1.Id, utils.ParseCoins("1000000denom1,1000000denom2"), true)
+	s.deposit(s.addr(5), pool2.Id, utils.ParseCoins("1000000denom2,1000000denom3"), true)
+	liquidity.EndBlocker(s.ctx, s.keeper)
+	liquidity.BeginBlocker(s.ctx, s.keeper)
+
+	depositReq1 := s.deposit(s.addr(4), pool1.Id, utils.ParseCoins("1000000denom1,1000000denom2"), true)
+	depositReq2 := s.deposit(s.addr(5), pool2.Id, utils.ParseCoins("1000000denom2,1000000denom3"), true)
+
+	withdrawReq1 := s.withdraw(s.addr(4), pool1.Id, utils.ParseCoin("1000000pool1"))
+	withdrawReq2 := s.withdraw(s.addr(5), pool2.Id, utils.ParseCoin("1000000pool2"))
+
+	order1 := s.limitOrder(s.addr(6), pair1.Id, types.OrderDirectionBuy, utils.ParseDec("1.0"), sdk.NewInt(10000), time.Minute, true)
+	order2 := s.limitOrder(s.addr(7), pair2.Id, types.OrderDirectionSell, utils.ParseDec("1.0"), sdk.NewInt(10000), time.Minute, true)
+
+	liquidity.EndBlocker(s.ctx, s.keeper)
+
+	genState := s.keeper.ExportGenesis(s.ctx)
+	s.SetupTest()
+	s.ctx = s.ctx.WithBlockHeight(1).WithBlockTime(utils.ParseTime("2022-03-02T00:00:00Z"))
+	s.keeper.InitGenesis(s.ctx, *genState)
+
+	// Check pair indexes.
+	pair, found := s.keeper.GetPairByDenoms(s.ctx, "denom1", "denom2")
+	s.Require().True(found)
+	s.Require().Equal(pair1.Id, pair.Id)
+
+	resp1, err := s.querier.Pairs(sdk.WrapSDKContext(s.ctx), &types.QueryPairsRequest{
+		Denoms: []string{"denom2", "denom1"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp1.Pairs, 1)
+	s.Require().Equal(pair1.Id, resp1.Pairs[0].Id)
+
+	resp2, err := s.querier.Pairs(sdk.WrapSDKContext(s.ctx), &types.QueryPairsRequest{
+		Denoms: []string{"denom2", "denom3"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp2.Pairs, 1)
+	s.Require().Equal(pair2.Id, resp2.Pairs[0].Id)
+
+	// Check pool indexes.
+	pools := s.keeper.GetPoolsByPair(s.ctx, pair2.Id)
+	s.Require().Len(pools, 1)
+	s.Require().Equal(pool2.Id, pools[0].Id)
+
+	pool, found := s.keeper.GetPoolByReserveAddress(s.ctx, pool1.GetReserveAddress())
+	s.Require().True(found)
+	s.Require().Equal(pool1.Id, pool.Id)
+
+	// Check deposit request indexes.
+	depositReqs := s.keeper.GetDepositRequestsByDepositor(s.ctx, s.addr(4))
+	s.Require().Len(depositReqs, 1)
+	s.Require().Equal(depositReq1.Id, depositReqs[0].Id)
+
+	depositReqs = s.keeper.GetDepositRequestsByDepositor(s.ctx, s.addr(5))
+	s.Require().Len(depositReqs, 1)
+	s.Require().Equal(depositReq2.Id, depositReqs[0].Id)
+
+	// Check withdraw request indexes
+	withdrawReqs := s.keeper.GetWithdrawRequestsByWithdrawer(s.ctx, s.addr(4))
+	s.Require().Len(withdrawReqs, 1)
+	s.Require().Equal(withdrawReq1.Id, withdrawReqs[0].Id)
+
+	withdrawReqs = s.keeper.GetWithdrawRequestsByWithdrawer(s.ctx, s.addr(5))
+	s.Require().Len(withdrawReqs, 1)
+	s.Require().Equal(withdrawReq2.Id, withdrawReqs[0].Id)
+
+	// Check order indexes
+	orders := s.keeper.GetOrdersByOrderer(s.ctx, s.addr(6))
+	s.Require().Len(orders, 1)
+	s.Require().Equal(order1.Id, orders[0].Id)
+
+	orders = s.keeper.GetOrdersByOrderer(s.ctx, s.addr(7))
+	s.Require().Len(orders, 1)
+	s.Require().Equal(order2.Id, orders[0].Id)
 }

--- a/x/liquidity/keeper/pair.go
+++ b/x/liquidity/keeper/pair.go
@@ -49,6 +49,9 @@ func (k Keeper) CreatePair(ctx sdk.Context, msg *types.MsgCreatePair) (types.Pai
 	id := k.getNextPairIdWithUpdate(ctx)
 	pair := types.NewPair(id, msg.BaseCoinDenom, msg.QuoteCoinDenom)
 	k.SetPair(ctx, pair)
+	k.SetPairIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
+	k.SetPairLookupIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
+	k.SetPairLookupIndex(ctx, pair.QuoteCoinDenom, pair.BaseCoinDenom, pair.Id)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(

--- a/x/liquidity/keeper/pair_test.go
+++ b/x/liquidity/keeper/pair_test.go
@@ -1,0 +1,22 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmosquad-labs/squad/x/liquidity/types"
+)
+
+func (s *KeeperTestSuite) TestPairIndexes() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	pair2, found := s.keeper.GetPairByDenoms(s.ctx, "denom1", "denom2")
+	s.Require().True(found)
+	s.Require().Equal(pair.Id, pair2.Id)
+
+	resp, err := s.querier.Pairs(sdk.WrapSDKContext(s.ctx), &types.QueryPairsRequest{
+		Denoms: []string{"denom2"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp.Pairs, 1)
+	s.Require().Equal(pair.Id, resp.Pairs[0].Id)
+}

--- a/x/liquidity/keeper/pool.go
+++ b/x/liquidity/keeper/pool.go
@@ -116,6 +116,8 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg *types.MsgCreatePool) (types.Poo
 	poolId := k.getNextPoolIdWithUpdate(ctx)
 	pool := types.NewPool(poolId, pair.Id)
 	k.SetPool(ctx, pool)
+	k.SetPoolByReserveIndex(ctx, pool)
+	k.SetPoolsByPairIndex(ctx, pool)
 
 	// Send deposit coins to the pool's reserve account.
 	creator := msg.GetCreator()
@@ -194,6 +196,7 @@ func (k Keeper) Deposit(ctx sdk.Context, msg *types.MsgDeposit) (types.DepositRe
 	requestId := k.getNextDepositRequestIdWithUpdate(ctx, pool)
 	req := types.NewDepositRequest(msg, pool, requestId, ctx.BlockHeight())
 	k.SetDepositRequest(ctx, req)
+	k.SetDepositRequestIndex(ctx, req)
 
 	params := k.GetParams(ctx)
 	ctx.GasMeter().ConsumeGas(params.DepositExtraGas, "DepositExtraGas")
@@ -242,6 +245,7 @@ func (k Keeper) Withdraw(ctx sdk.Context, msg *types.MsgWithdraw) (types.Withdra
 	requestId := k.getNextWithdrawRequestIdWithUpdate(ctx, pool)
 	req := types.NewWithdrawRequest(msg, requestId, ctx.BlockHeight())
 	k.SetWithdrawRequest(ctx, req)
+	k.SetWithdrawRequestIndex(ctx, req)
 
 	params := k.GetParams(ctx)
 	ctx.GasMeter().ConsumeGas(params.WithdrawExtraGas, "WithdrawExtraGas")

--- a/x/liquidity/keeper/pool_test.go
+++ b/x/liquidity/keeper/pool_test.go
@@ -155,6 +155,20 @@ func (s *KeeperTestSuite) TestCreatePoolInitialPoolCoinSupply() {
 	s.Require().True(intEq(sdk.NewInt(100000000000000), s.getBalance(poolCreator, pool.PoolCoinDenom).Amount))
 }
 
+func (s *KeeperTestSuite) TestPoolIndexes() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	pool := s.createPool(s.addr(1), pair.Id, utils.ParseCoins("1000000denom1,1000000denom2"), true)
+
+	pool2, found := s.keeper.GetPoolByReserveAddress(s.ctx, pool.GetReserveAddress())
+	s.Require().True(found)
+	s.Require().Equal(pool.Id, pool2.Id)
+
+	pools := s.keeper.GetPoolsByPair(s.ctx, pair.Id)
+	s.Require().Len(pools, 1)
+	s.Require().Equal(pool.Id, pools[0].Id)
+}
+
 func (s *KeeperTestSuite) TestDeposit() {
 	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
 	pool := s.createPool(s.addr(0), pair.Id, utils.ParseCoins("1000000denom1,1000000denom2"), true)

--- a/x/liquidity/keeper/store.go
+++ b/x/liquidity/keeper/store.go
@@ -58,9 +58,6 @@ func (k Keeper) SetPair(ctx sdk.Context, pair types.Pair) {
 	store := ctx.KVStore(k.storeKey)
 	bz := types.MustMarshalPair(k.cdc, pair)
 	store.Set(types.GetPairKey(pair.Id), bz)
-	k.SetPairIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
-	k.SetPairLookupIndex(ctx, pair.BaseCoinDenom, pair.QuoteCoinDenom, pair.Id)
-	k.SetPairLookupIndex(ctx, pair.QuoteCoinDenom, pair.BaseCoinDenom, pair.Id)
 }
 
 // SetPairIndex stores a pair index.
@@ -155,8 +152,6 @@ func (k Keeper) SetPool(ctx sdk.Context, pool types.Pool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := types.MustMarshalPool(k.cdc, pool)
 	store.Set(types.GetPoolKey(pool.Id), bz)
-	k.SetPoolByReserveIndex(ctx, pool)
-	k.SetPoolsByPairIndex(ctx, pool)
 }
 
 // SetPoolByReserveIndex stores a pool by reserve account index key.
@@ -246,6 +241,10 @@ func (k Keeper) SetDepositRequest(ctx sdk.Context, req types.DepositRequest) {
 	store := ctx.KVStore(k.storeKey)
 	bz := types.MustMarshalDepositRequest(k.cdc, req)
 	store.Set(types.GetDepositRequestKey(req.PoolId, req.Id), bz)
+}
+
+func (k Keeper) SetDepositRequestIndex(ctx sdk.Context, req types.DepositRequest) {
+	store := ctx.KVStore(k.storeKey)
 	store.Set(types.GetDepositRequestIndexKey(req.GetDepositor(), req.PoolId, req.Id), []byte{})
 }
 
@@ -311,6 +310,11 @@ func (k Keeper) GetDepositRequestsByDepositor(ctx sdk.Context, depositor sdk.Acc
 func (k Keeper) DeleteDepositRequest(ctx sdk.Context, req types.DepositRequest) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetDepositRequestKey(req.PoolId, req.Id))
+	k.DeleteDepositRequestIndex(ctx, req)
+}
+
+func (k Keeper) DeleteDepositRequestIndex(ctx sdk.Context, req types.DepositRequest) {
+	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetDepositRequestIndexKey(req.GetDepositor(), req.PoolId, req.Id))
 }
 
@@ -330,6 +334,10 @@ func (k Keeper) SetWithdrawRequest(ctx sdk.Context, req types.WithdrawRequest) {
 	store := ctx.KVStore(k.storeKey)
 	bz := types.MustMarshaWithdrawRequest(k.cdc, req)
 	store.Set(types.GetWithdrawRequestKey(req.PoolId, req.Id), bz)
+}
+
+func (k Keeper) SetWithdrawRequestIndex(ctx sdk.Context, req types.WithdrawRequest) {
+	store := ctx.KVStore(k.storeKey)
 	store.Set(types.GetWithdrawRequestIndexKey(req.GetWithdrawer(), req.PoolId, req.Id), []byte{})
 }
 
@@ -395,6 +403,11 @@ func (k Keeper) GetWithdrawRequestsByWithdrawer(ctx sdk.Context, withdrawer sdk.
 func (k Keeper) DeleteWithdrawRequest(ctx sdk.Context, req types.WithdrawRequest) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetWithdrawRequestKey(req.PoolId, req.Id))
+	k.DeleteWithdrawRequestIndex(ctx, req)
+}
+
+func (k Keeper) DeleteWithdrawRequestIndex(ctx sdk.Context, req types.WithdrawRequest) {
+	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetWithdrawRequestIndexKey(req.GetWithdrawer(), req.PoolId, req.Id))
 }
 
@@ -414,6 +427,10 @@ func (k Keeper) SetOrder(ctx sdk.Context, order types.Order) {
 	store := ctx.KVStore(k.storeKey)
 	bz := types.MustMarshaOrder(k.cdc, order)
 	store.Set(types.GetOrderKey(order.PairId, order.Id), bz)
+}
+
+func (k Keeper) SetOrderIndex(ctx sdk.Context, order types.Order) {
+	store := ctx.KVStore(k.storeKey)
 	store.Set(types.GetOrderIndexKey(order.GetOrderer(), order.PairId, order.Id), []byte{})
 }
 
@@ -507,5 +524,10 @@ func (k Keeper) GetOrdersByOrderer(ctx sdk.Context, orderer sdk.AccAddress) (ord
 func (k Keeper) DeleteOrder(ctx sdk.Context, order types.Order) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetOrderKey(order.PairId, order.Id))
+	k.DeleteOrderIndex(ctx, order)
+}
+
+func (k Keeper) DeleteOrderIndex(ctx sdk.Context, order types.Order) {
+	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetOrderIndexKey(order.GetOrderer(), order.PairId, order.Id))
 }

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -91,6 +91,7 @@ func (k Keeper) LimitOrder(ctx sdk.Context, msg *types.MsgLimitOrder) (types.Ord
 	expireAt := ctx.BlockTime().Add(msg.OrderLifespan)
 	order := types.NewOrderForLimitOrder(msg, requestId, pair, offerCoin, price, expireAt, ctx.BlockHeight())
 	k.SetOrder(ctx, order)
+	k.SetOrderIndex(ctx, order)
 
 	params := k.GetParams(ctx)
 	ctx.GasMeter().ConsumeGas(params.OrderExtraGas, "OrderExtraGas")
@@ -182,6 +183,7 @@ func (k Keeper) MarketOrder(ctx sdk.Context, msg *types.MsgMarketOrder) (types.O
 	expireAt := ctx.BlockTime().Add(msg.OrderLifespan)
 	order := types.NewOrderForMarketOrder(msg, requestId, pair, offerCoin, price, expireAt, ctx.BlockHeight())
 	k.SetOrder(ctx, order)
+	k.SetOrderIndex(ctx, order)
 
 	params := k.GetParams(ctx)
 	ctx.GasMeter().ConsumeGas(params.OrderExtraGas, "OrderExtraGas")


### PR DESCRIPTION
## Description

There were some inefficient set operations of indexes when updating data with store methods like `SetPair`, `SetPool`, ...
This PR fixes that and set indexes only once when creating the data.