### PR TITLE
fix: handle small orders correctly

### DIFF
--- a/x/liquidity/amm/match.go
+++ b/x/liquidity/amm/match.go
@@ -124,6 +124,9 @@ func FindLastMatchableOrders(buyOrders, sellOrders []Order, matchPrice sdk.Dec) 
 // received quote coin.
 // quoteCoinDust can be positive because of the decimal truncation.
 func MatchOrders(buyOrders, sellOrders []Order, matchPrice sdk.Dec) (quoteCoinDust sdk.Int, matched bool) {
+	buyOrders = DropSmallOrders(buyOrders, matchPrice)
+	sellOrders = DropSmallOrders(sellOrders, matchPrice)
+
 	bi, si, pmb, pms, found := FindLastMatchableOrders(buyOrders, sellOrders, matchPrice)
 	if !found {
 		return sdk.Int{}, false
@@ -164,4 +167,17 @@ func MatchOrders(buyOrders, sellOrders []Order, matchPrice sdk.Dec) (quoteCoinDu
 	}
 
 	return quoteCoinDust, true
+}
+
+// DropSmallOrders returns filtered orders, where orders with too small amount
+// are dropped.
+func DropSmallOrders(orders []Order, matchPrice sdk.Dec) []Order {
+	var res []Order
+	for _, order := range orders {
+		openAmt := order.GetOpenAmount()
+		if openAmt.IsPositive() && matchPrice.MulInt(openAmt).TruncateInt().IsPositive() {
+			res = append(res, order)
+		}
+	}
+	return res
 }

--- a/x/liquidity/keeper/batch.go
+++ b/x/liquidity/keeper/batch.go
@@ -22,6 +22,11 @@ func (k Keeper) ExecuteRequests(ctx sdk.Context) {
 			if err := k.FinishOrder(ctx, order, types.OrderStatusExpired); err != nil {
 				return false, err
 			}
+		} else if types.IsTooSmallOrderAmount(order.OpenAmount, order.Price) {
+			// TODO: should we introduce new order status for this type of expiration?
+			if err := k.FinishOrder(ctx, order, types.OrderStatusExpired); err != nil {
+				return false, err
+			}
 		}
 		return false, nil
 	}); err != nil {

--- a/x/liquidity/keeper/grpc_query_test.go
+++ b/x/liquidity/keeper/grpc_query_test.go
@@ -763,7 +763,7 @@ func (s *KeeperTestSuite) TestGRPCOrder() {
 
 func (s *KeeperTestSuite) TestGRPCOrdersByOrderer() {
 	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
-	pair2 := s.createPair(s.addr(0), "denom2", "denom2", true)
+	pair2 := s.createPair(s.addr(0), "denom2", "denom3", true)
 
 	order := s.buyLimitOrder(s.addr(1), pair.Id, utils.ParseDec("1.0"), sdk.NewInt(1000000), time.Minute, true)
 	order2 := s.buyLimitOrder(s.addr(1), pair2.Id, utils.ParseDec("1.0"), sdk.NewInt(1000000), time.Minute, true)

--- a/x/liquidity/keeper/keeper_test.go
+++ b/x/liquidity/keeper/keeper_test.go
@@ -49,6 +49,7 @@ func (s *KeeperTestSuite) getBalance(addr sdk.AccAddress, denom string) sdk.Coin
 }
 
 func (s *KeeperTestSuite) sendCoins(fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) {
+	s.T().Helper()
 	err := s.app.BankKeeper.SendCoins(s.ctx, fromAddr, toAddr, amt)
 	s.Require().NoError(err)
 }
@@ -66,6 +67,7 @@ func (s *KeeperTestSuite) addr(addrNum int) sdk.AccAddress {
 }
 
 func (s *KeeperTestSuite) fundAddr(addr sdk.AccAddress, amt sdk.Coins) {
+	s.T().Helper()
 	err := s.app.BankKeeper.MintCoins(s.ctx, types.ModuleName, amt)
 	s.Require().NoError(err)
 	err = s.app.BankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.ModuleName, addr, amt)
@@ -73,6 +75,7 @@ func (s *KeeperTestSuite) fundAddr(addr sdk.AccAddress, amt sdk.Coins) {
 }
 
 func (s *KeeperTestSuite) createPair(creator sdk.AccAddress, baseCoinDenom, quoteCoinDenom string, fund bool) types.Pair {
+	s.T().Helper()
 	params := s.keeper.GetParams(s.ctx)
 	if fund {
 		s.fundAddr(creator, params.PairCreationFee)
@@ -83,6 +86,7 @@ func (s *KeeperTestSuite) createPair(creator sdk.AccAddress, baseCoinDenom, quot
 }
 
 func (s *KeeperTestSuite) createPool(creator sdk.AccAddress, pairId uint64, depositCoins sdk.Coins, fund bool) types.Pool {
+	s.T().Helper()
 	params := s.keeper.GetParams(s.ctx)
 	if fund {
 		s.fundAddr(creator, depositCoins.Add(params.PoolCreationFee...))
@@ -93,6 +97,7 @@ func (s *KeeperTestSuite) createPool(creator sdk.AccAddress, pairId uint64, depo
 }
 
 func (s *KeeperTestSuite) deposit(depositor sdk.AccAddress, poolId uint64, depositCoins sdk.Coins, fund bool) types.DepositRequest {
+	s.T().Helper()
 	if fund {
 		s.fundAddr(depositor, depositCoins)
 	}
@@ -102,6 +107,7 @@ func (s *KeeperTestSuite) deposit(depositor sdk.AccAddress, poolId uint64, depos
 }
 
 func (s *KeeperTestSuite) withdraw(withdrawer sdk.AccAddress, poolId uint64, poolCoin sdk.Coin) types.WithdrawRequest {
+	s.T().Helper()
 	req, err := s.keeper.Withdraw(s.ctx, types.NewMsgWithdraw(withdrawer, poolId, poolCoin))
 	s.Require().NoError(err)
 	return req
@@ -110,6 +116,7 @@ func (s *KeeperTestSuite) withdraw(withdrawer sdk.AccAddress, poolId uint64, poo
 func (s *KeeperTestSuite) limitOrder(
 	orderer sdk.AccAddress, pairId uint64, dir types.OrderDirection,
 	price sdk.Dec, amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	pair, found := s.keeper.GetPair(s.ctx, pairId)
 	s.Require().True(found)
 	var ammDir amm.OrderDirection
@@ -137,6 +144,7 @@ func (s *KeeperTestSuite) limitOrder(
 func (s *KeeperTestSuite) buyLimitOrder(
 	orderer sdk.AccAddress, pairId uint64, price sdk.Dec,
 	amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	return s.limitOrder(
 		orderer, pairId, types.OrderDirectionBuy, price, amt, orderLifespan, fund)
 }
@@ -144,6 +152,7 @@ func (s *KeeperTestSuite) buyLimitOrder(
 func (s *KeeperTestSuite) sellLimitOrder(
 	orderer sdk.AccAddress, pairId uint64, price sdk.Dec,
 	amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	return s.limitOrder(
 		orderer, pairId, types.OrderDirectionSell, price, amt, orderLifespan, fund)
 }
@@ -151,6 +160,7 @@ func (s *KeeperTestSuite) sellLimitOrder(
 func (s *KeeperTestSuite) marketOrder(
 	orderer sdk.AccAddress, pairId uint64, dir types.OrderDirection,
 	amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	pair, found := s.keeper.GetPair(s.ctx, pairId)
 	s.Require().True(found)
 	s.Require().NotNil(pair.LastPrice)
@@ -181,6 +191,7 @@ func (s *KeeperTestSuite) marketOrder(
 func (s *KeeperTestSuite) buyMarketOrder(
 	orderer sdk.AccAddress, pairId uint64,
 	amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	return s.marketOrder(
 		orderer, pairId, types.OrderDirectionBuy, amt, orderLifespan, fund)
 }
@@ -189,17 +200,20 @@ func (s *KeeperTestSuite) buyMarketOrder(
 func (s *KeeperTestSuite) sellMarketOrder(
 	orderer sdk.AccAddress, pairId uint64,
 	amt sdk.Int, orderLifespan time.Duration, fund bool) types.Order {
+	s.T().Helper()
 	return s.marketOrder(
 		orderer, pairId, types.OrderDirectionSell, amt, orderLifespan, fund)
 }
 
 //nolint
 func (s *KeeperTestSuite) cancelOrder(orderer sdk.AccAddress, pairId, orderId uint64) {
+	s.T().Helper()
 	err := s.keeper.CancelOrder(s.ctx, types.NewMsgCancelOrder(orderer, pairId, orderId))
 	s.Require().NoError(err)
 }
 
 func (s *KeeperTestSuite) cancelAllOrders(orderer sdk.AccAddress, pairIds []uint64) {
+	s.T().Helper()
 	err := s.keeper.CancelAllOrders(s.ctx, types.NewMsgCancelAllOrders(orderer, pairIds))
 	s.Require().NoError(err)
 }

--- a/x/liquidity/keeper/keeper_test.go
+++ b/x/liquidity/keeper/keeper_test.go
@@ -80,7 +80,9 @@ func (s *KeeperTestSuite) createPair(creator sdk.AccAddress, baseCoinDenom, quot
 	if fund {
 		s.fundAddr(creator, params.PairCreationFee)
 	}
-	pair, err := s.keeper.CreatePair(s.ctx, types.NewMsgCreatePair(creator, baseCoinDenom, quoteCoinDenom))
+	msg := types.NewMsgCreatePair(creator, baseCoinDenom, quoteCoinDenom)
+	s.Require().NoError(msg.ValidateBasic())
+	pair, err := s.keeper.CreatePair(s.ctx, msg)
 	s.Require().NoError(err)
 	return pair
 }
@@ -91,7 +93,9 @@ func (s *KeeperTestSuite) createPool(creator sdk.AccAddress, pairId uint64, depo
 	if fund {
 		s.fundAddr(creator, depositCoins.Add(params.PoolCreationFee...))
 	}
-	pool, err := s.keeper.CreatePool(s.ctx, types.NewMsgCreatePool(creator, pairId, depositCoins))
+	msg := types.NewMsgCreatePool(creator, pairId, depositCoins)
+	s.Require().NoError(msg.ValidateBasic())
+	pool, err := s.keeper.CreatePool(s.ctx, msg)
 	s.Require().NoError(err)
 	return pool
 }
@@ -136,6 +140,7 @@ func (s *KeeperTestSuite) limitOrder(
 	msg := types.NewMsgLimitOrder(
 		orderer, pairId, dir, offerCoin, demandCoinDenom,
 		price, amt, orderLifespan)
+	s.Require().NoError(msg.ValidateBasic())
 	req, err := s.keeper.LimitOrder(s.ctx, msg)
 	s.Require().NoError(err)
 	return req
@@ -183,6 +188,7 @@ func (s *KeeperTestSuite) marketOrder(
 	msg := types.NewMsgMarketOrder(
 		orderer, pairId, dir, offerCoin, demandCoinDenom,
 		amt, orderLifespan)
+	s.Require().NoError(msg.ValidateBasic())
 	req, err := s.keeper.MarketOrder(s.ctx, msg)
 	s.Require().NoError(err)
 	return req

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -70,6 +70,9 @@ func (k Keeper) ValidateMsgLimitOrder(ctx sdk.Context, msg *types.MsgLimitOrder)
 				types.ErrInsufficientOfferCoin, "%s is smaller than %s", msg.OfferCoin, sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount))
 		}
 	}
+	if types.IsTooSmallOrderAmount(msg.Amount, price) {
+		return sdk.Coin{}, sdk.Dec{}, types.ErrTooSmallOrder
+	}
 
 	return offerCoin, price, nil
 }
@@ -161,6 +164,9 @@ func (k Keeper) ValidateMsgMarketOrder(ctx sdk.Context, msg *types.MsgMarketOrde
 			return sdk.Coin{}, sdk.Dec{}, sdkerrors.Wrapf(
 				types.ErrInsufficientOfferCoin, "%s is smaller than %s", msg.OfferCoin, sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount))
 		}
+	}
+	if types.IsTooSmallOrderAmount(msg.Amount, price) {
+		return sdk.Coin{}, sdk.Dec{}, types.ErrTooSmallOrder
 	}
 
 	return offerCoin, price, nil

--- a/x/liquidity/simulation/operations_test.go
+++ b/x/liquidity/simulation/operations_test.go
@@ -155,11 +155,11 @@ func (s *SimTestSuite) TestSimulateMsgLimitOrder() {
 	s.Require().Equal("cosmos1tp4es44j4vv8m59za3z0tm64dkmlnm8wg2frhc", msg.Orderer)
 	s.Require().Equal(pair.Id, msg.PairId)
 	s.Require().Equal(types.OrderDirectionSell, msg.Direction)
-	s.Require().Equal("239747denom1", msg.OfferCoin.String())
+	s.Require().Equal("6010denom1", msg.OfferCoin.String())
 	s.Require().Equal("stake", msg.DemandCoinDenom)
-	s.Require().Equal("5.439000000000000000", msg.Price.String())
-	s.Require().Equal("239747", msg.Amount.String())
-	s.Require().Equal("15h40m44.578894929s", msg.OrderLifespan.String())
+	s.Require().Equal("1.228000000000000000", msg.Price.String())
+	s.Require().Equal("6010", msg.Amount.String())
+	s.Require().Equal("9h14m25.122290029s", msg.OrderLifespan.String())
 }
 
 func (s *SimTestSuite) TestSimulateMsgMarketOrder() {
@@ -187,10 +187,10 @@ func (s *SimTestSuite) TestSimulateMsgMarketOrder() {
 	s.Require().Equal("cosmos1tp4es44j4vv8m59za3z0tm64dkmlnm8wg2frhc", msg.Orderer)
 	s.Require().Equal(pair.Id, msg.PairId)
 	s.Require().Equal(types.OrderDirectionSell, msg.Direction)
-	s.Require().Equal("668250denom1", msg.OfferCoin.String())
+	s.Require().Equal("10383denom1", msg.OfferCoin.String())
 	s.Require().Equal("stake", msg.DemandCoinDenom)
-	s.Require().Equal("668250", msg.Amount.String())
-	s.Require().Equal("4h54m51.286980153s", msg.OrderLifespan.String())
+	s.Require().Equal("10383", msg.Amount.String())
+	s.Require().Equal("15h40m44.578894929s", msg.OrderLifespan.String())
 }
 
 func (s *SimTestSuite) TestSimulateMsgCancelOrder() {

--- a/x/liquidity/types/errors.go
+++ b/x/liquidity/types/errors.go
@@ -22,4 +22,5 @@ var (
 	ErrSameBatch                 = sdkerrors.Register(ModuleName, 14, "cannot cancel an order within the same batch")
 	ErrAlreadyCanceled           = sdkerrors.Register(ModuleName, 15, "the order is already canceled")
 	ErrDuplicatePairId           = sdkerrors.Register(ModuleName, 16, "duplicate pair id presents in the pair id list")
+	ErrTooSmallOrder             = sdkerrors.Register(ModuleName, 17, "too small order")
 )

--- a/x/liquidity/types/msgs.go
+++ b/x/liquidity/types/msgs.go
@@ -300,7 +300,7 @@ func (msg MsgLimitOrder) ValidateBasic() error {
 		minOfferCoin = sdk.NewCoin(msg.OfferCoin.Denom, msg.Amount)
 	}
 	if msg.OfferCoin.IsLT(minOfferCoin) {
-		return sdkerrors.Wrapf(ErrInsufficientOfferCoin, "%s is smaller than %s", msg.OfferCoin, minOfferCoin)
+		return sdkerrors.Wrapf(ErrInsufficientOfferCoin, "%s is less than %s", msg.OfferCoin, minOfferCoin)
 	}
 	if msg.Amount.LT(MinCoinAmount) {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "base coin is less than minimum coin amount")

--- a/x/liquidity/types/msgs_test.go
+++ b/x/liquidity/types/msgs_test.go
@@ -301,7 +301,7 @@ func TestMsgLimitOrder(t *testing.T) {
 				msg.Price = utils.ParseDec("10")
 				msg.Amount = newInt(1000000)
 			},
-			"1000000denom2 is smaller than 10000000denom2: insufficient offer coin",
+			"1000000denom2 is less than 10000000denom2: insufficient offer coin",
 		},
 		{
 			"invalid demand coin denom",

--- a/x/liquidity/types/pool.go
+++ b/x/liquidity/types/pool.go
@@ -107,7 +107,7 @@ func NewBasicPoolOrderSource(
 
 func (os *BasicPoolOrderSource) BuyOrdersOver(price sdk.Dec) []amm.Order {
 	amt := os.BuyAmountOver(price)
-	if amt.IsZero() {
+	if IsTooSmallOrderAmount(amt, price) {
 		return nil
 	}
 	quoteCoin := sdk.NewCoin(os.QuoteCoinDenom, amm.OfferCoinAmount(amm.Buy, price, amt))
@@ -116,7 +116,7 @@ func (os *BasicPoolOrderSource) BuyOrdersOver(price sdk.Dec) []amm.Order {
 
 func (os *BasicPoolOrderSource) SellOrdersUnder(price sdk.Dec) []amm.Order {
 	amt := os.SellAmountUnder(price)
-	if amt.IsZero() {
+	if IsTooSmallOrderAmount(amt, price) {
 		return nil
 	}
 	baseCoin := sdk.NewCoin(os.BaseCoinDenom, amt)

--- a/x/liquidity/types/util.go
+++ b/x/liquidity/types/util.go
@@ -34,3 +34,9 @@ func (op *BulkSendCoinsOperation) Run(ctx sdk.Context, bankKeeper BankKeeper) er
 	}
 	return nil
 }
+
+// IsTooSmallOrderAmount returns whether the order amount is too small for
+// matching, based on the order price.
+func IsTooSmallOrderAmount(amt sdk.Int, price sdk.Dec) bool {
+	return amt.LT(MinCoinAmount) || price.MulInt(amt).LT(MinCoinAmount.ToDec())
+}


### PR DESCRIPTION
## Description

Closes: #275, #195 

## Tasks

- [x] reject orders with small amount(or small (amount*price)) in msg server
- [x] expire orders with small amount in end-block
- [x] pools don't make orders with small amount
- [x] drop small orders in `MatchOrders`
- [x] add tests