### PR TITLE
fix: check if orderer has sufficient offer coin balances

### DIFF
--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -16,6 +16,13 @@ import (
 // ValidateMsgLimitOrder validates types.MsgLimitOrder with state and returns
 // calculated offer coin and price that is fit into ticks.
 func (k Keeper) ValidateMsgLimitOrder(ctx sdk.Context, msg *types.MsgLimitOrder) (offerCoin sdk.Coin, price sdk.Dec, err error) {
+	spendable := k.bankKeeper.SpendableCoins(ctx, msg.GetOrderer())
+	if spendableAmt := spendable.AmountOf(msg.OfferCoin.Denom); spendableAmt.LT(msg.OfferCoin.Amount) {
+		return sdk.Coin{}, sdk.Dec{}, sdkerrors.Wrapf(
+			sdkerrors.ErrInsufficientFunds, "%s is smaller than %s",
+			sdk.NewCoin(msg.OfferCoin.Denom, spendableAmt), msg.OfferCoin)
+	}
+
 	params := k.GetParams(ctx)
 
 	if msg.OrderLifespan > params.MaxOrderLifespan {
@@ -122,6 +129,13 @@ func (k Keeper) LimitOrder(ctx sdk.Context, msg *types.MsgLimitOrder) (types.Ord
 // ValidateMsgMarketOrder validates types.MsgMarketOrder with state and returns
 // calculated offer coin and price.
 func (k Keeper) ValidateMsgMarketOrder(ctx sdk.Context, msg *types.MsgMarketOrder) (offerCoin sdk.Coin, price sdk.Dec, err error) {
+	spendable := k.bankKeeper.SpendableCoins(ctx, msg.GetOrderer())
+	if spendableAmt := spendable.AmountOf(msg.OfferCoin.Denom); spendableAmt.LT(msg.OfferCoin.Amount) {
+		return sdk.Coin{}, sdk.Dec{}, sdkerrors.Wrapf(
+			sdkerrors.ErrInsufficientFunds, "%s is smaller than %s",
+			sdk.NewCoin(msg.OfferCoin.Denom, spendableAmt), msg.OfferCoin)
+	}
+
 	params := k.GetParams(ctx)
 
 	if msg.OrderLifespan > params.MaxOrderLifespan {

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -214,7 +214,7 @@ func (k Keeper) MarketOrder(ctx sdk.Context, msg *types.MsgMarketOrder) (types.O
 			sdk.NewAttribute(types.AttributeKeyOrderer, msg.Orderer),
 			sdk.NewAttribute(types.AttributeKeyPairId, strconv.FormatUint(msg.PairId, 10)),
 			sdk.NewAttribute(types.AttributeKeyOrderDirection, msg.Direction.String()),
-			sdk.NewAttribute(types.AttributeKeyOfferCoin, msg.OfferCoin.String()),
+			sdk.NewAttribute(types.AttributeKeyOfferCoin, offerCoin.String()),
 			sdk.NewAttribute(types.AttributeKeyDemandCoinDenom, msg.DemandCoinDenom),
 			sdk.NewAttribute(types.AttributeKeyPrice, price.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, msg.Amount.String()),

--- a/x/liquidity/keeper/swap_test.go
+++ b/x/liquidity/keeper/swap_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	utils "github.com/cosmosquad-labs/squad/types"
 	"github.com/cosmosquad-labs/squad/x/liquidity"
@@ -113,6 +114,23 @@ func (s *KeeperTestSuite) TestLimitOrder() {
 	}
 }
 
+func (s *KeeperTestSuite) TestLimitOrderInsufficientOfferCoin() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	orderer := s.addr(1)
+	s.fundAddr(orderer, utils.ParseCoins("1000000denom2"))
+	_, err := s.keeper.LimitOrder(s.ctx, types.NewMsgLimitOrder(
+		orderer, pair.Id, types.OrderDirectionBuy, utils.ParseCoin("1000001denom2"), "denom1",
+		utils.ParseDec("1.0"), sdk.NewInt(1000000), 0))
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds)
+
+	s.fundAddr(orderer, utils.ParseCoins("1000000denom1"))
+	_, err = s.keeper.LimitOrder(s.ctx, types.NewMsgLimitOrder(
+		orderer, pair.Id, types.OrderDirectionSell, utils.ParseCoin("1000001denom1"), "denom2",
+		utils.ParseDec("1.0"), sdk.NewInt(1000000), 0))
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds)
+}
+
 func (s *KeeperTestSuite) TestLimitOrderRefund() {
 	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
 	orderer := s.addr(1)
@@ -194,6 +212,23 @@ func (s *KeeperTestSuite) TestMarketOrder() {
 	// Check the result.
 	s.Require().True(coinEq(utils.ParseCoin("10000denom1"), s.getBalance(s.addr(3), "denom1")))
 	s.Require().True(coinsEq(utils.ParseCoins("10800denom2"), s.getBalances(s.addr(4))))
+}
+
+func (s *KeeperTestSuite) TestMarketOrderInsufficientOfferCoin() {
+	pair := s.createPair(s.addr(0), "denom1", "denom2", true)
+
+	orderer := s.addr(1)
+	s.fundAddr(orderer, utils.ParseCoins("1000000denom2"))
+	_, err := s.keeper.MarketOrder(s.ctx, types.NewMsgMarketOrder(
+		orderer, pair.Id, types.OrderDirectionBuy, utils.ParseCoin("1000001denom2"), "denom1",
+		sdk.NewInt(1000000), 0))
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds)
+
+	s.fundAddr(orderer, utils.ParseCoins("1000000denom1"))
+	_, err = s.keeper.MarketOrder(s.ctx, types.NewMsgMarketOrder(
+		orderer, pair.Id, types.OrderDirectionSell, utils.ParseCoin("1000001denom1"), "denom2",
+		sdk.NewInt(1000000), 0))
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds)
 }
 
 func (s *KeeperTestSuite) TestMarketOrderRefund() {


### PR DESCRIPTION
## Description

### Important note

This fix doesn't indicate that we didn't have such important check before.
This PR just adds another check that prevents orderers to specify more offer coins than they have in order msgs.

## Tasks

- [x] Add check for `MsgLimitOrder`
- [x] Add check for `MsgMarketOrder`
- [x] Fix inconsistent tx event of `MarketOrder`.