### PR TITLE
fix: limit the number of active pools in a pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,23 +38,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## v2.1.0
+
 ### Client Breaking Changes
 
 * (x/liquidity) [\#338](https://github.com/cosmosquad-labs/squad/pull/338) Refactor `OrderBooks` query:
   * `tick_precisions` field has been removed from `QueryOrderBooksRequest`
   * `tick_precision` field has been removed from `OrderBookResponse` and `price_unit` has been added instead
   * The order between `sells` and `buys` has been changed
-
-### CLI Breaking Changes
-
-* (x/liquidity) [\#338](https://github.com/cosmosquad-labs/squad/pull/338) Refactor `order-books` query cmd:
-  * `[tick-precisions]` argument has been removed: `order-books [pair-ids]`
-  * Response structure has been changed
-
-## v2.0.0
-
-### Client Breaking Changes
-
 * (x/liquidity) [\#335](https://github.com/cosmosquad-labs/squad/pull/335) Modify `PoolResponse`:
   * `balances` field has been modified to contain `base_coin` and `quote_coin` fields
   * `pool_coin_supply` field has been added
@@ -70,6 +61,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### CLI Breaking Changes
 
+* (x/liquidity) [\#338](https://github.com/cosmosquad-labs/squad/pull/338) Refactor `order-books` query cmd:
+  * `[tick-precisions]` argument has been removed: `order-books [pair-ids]`
+  * Response structure has been changed
 * (x/farming) [\#334](https://github.com/cosmosquad-labs/squad/pull/334) Add `historical-rewards` query cmd:
   * `historical-rewards [staking-coin-denom]`
 * (x/liquidity) [\#318](https://github.com/cosmosquad-labs/squad/pull/318) Add `create-ranged-pool` tx cmd and `order-books` query cmd:
@@ -82,6 +76,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### State Machine Breaking
 
+* (x/liquidity) [\#340](https://github.com/cosmosquad-labs/squad/pull/340) Add `MaxNumActivePoolsPerPair` global constant
 * (x/liquidity) [\#318](https://github.com/cosmosquad-labs/squad/pull/318) Change `Pool` struct for ranged pools and refactor matching logic
   * Add `type`, `creator`, `min_price` and `max_price` fields to `Pool` struct
   * Refactor matching logic both for fairness of matching and efficiency of pool order placement

--- a/x/liquidity/types/errors.go
+++ b/x/liquidity/types/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrDuplicatePairId           = sdkerrors.Register(ModuleName, 16, "duplicate pair id presents in the pair id list")
 	ErrTooSmallOrder             = sdkerrors.Register(ModuleName, 17, "too small order")
 	ErrTooLargePool              = sdkerrors.Register(ModuleName, 18, "too large pool")
+	ErrTooManyPools              = sdkerrors.Register(ModuleName, 19, "too many pools in the pair")
 )

--- a/x/liquidity/types/params.go
+++ b/x/liquidity/types/params.go
@@ -39,6 +39,10 @@ const (
 	PairEscrowAddressPrefix   = "PairEscrowAddress"
 	ModuleAddressNameSplitter = "|"
 	AddressType               = farmingtypes.AddressType32Bytes
+
+	// MaxNumActivePoolsPerPair is the maximum number of active(not disabled)
+	// pools per pair.
+	MaxNumActivePoolsPerPair = 50
 )
 
 var (


### PR DESCRIPTION
## Description

This PR adds the limit of number of active pools in a pair, which is `50` by default.

## Tasks

- [x] Add `MaxNumActivePoolsPerPair` global constant
- [x] Add unit tests

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
