### PR TITLE
refactor!: detailed configuration for order book responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## v2.1.1
+
+### Improvements
+
+* (x/liquidity) [\#341](https://github.com/cosmosquad-labs/squad/pull/341) Enable detailed configuration for order book responses
+
 ## v2.1.0
 
 ### Client Breaking Changes

--- a/x/liquidity/keeper/grpc_query.go
+++ b/x/liquidity/keeper/grpc_query.go
@@ -555,7 +555,21 @@ func (k Querier) OrderBooks(c context.Context, req *types.QueryOrderBooksRequest
 		ov := ob.MakeView()
 		ov.Match()
 
-		pairs = append(pairs, types.MakeOrderBookPairResponse(pair.Id, ov, lowestPrice, highestPrice, int(tickPrec), int(req.NumTicks)))
+		pairs = append(
+			pairs, types.MakeOrderBookPairResponse(
+				pair.Id, ov, lowestPrice, highestPrice, int(tickPrec),
+				types.OrderBookConfig{
+					PriceUnitPower: 0,
+					MaxNumTicks:    int(req.NumTicks),
+				},
+				types.OrderBookConfig{
+					PriceUnitPower: 1,
+					MaxNumTicks:    int(req.NumTicks),
+				},
+				types.OrderBookConfig{
+					PriceUnitPower: 2,
+					MaxNumTicks:    int(req.NumTicks),
+				}))
 	}
 
 	return &types.QueryOrderBooksResponse{

--- a/x/liquidity/types/example_orderbook_test.go
+++ b/x/liquidity/types/example_orderbook_test.go
@@ -25,7 +25,10 @@ func ExampleMakeOrderBookPairResponse() {
 	tickPrec := 1
 	lowestPrice := utils.ParseDec("0")
 	highestPrice := utils.ParseDec("20")
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, 20)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    20,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 
 	// Output:
@@ -62,7 +65,10 @@ func ExampleMakeOrderBookPairResponse_pool() {
 	ov := ob.MakeView()
 	ov.Match()
 	tickPrec := 3
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 
 	// Output:
@@ -113,7 +119,10 @@ func ExampleMakeOrderBookPairResponse_userOrder() {
 	ov := ob.MakeView()
 	ov.Match()
 	tickPrec := 3
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, tickPrec, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	basePrice, found := types.OrderBookBasePrice(ov, tickPrec)
 	if !found {
 		panic("base price not found")
@@ -159,7 +168,10 @@ func ExampleMakeOrderBookPairResponse_match() {
 	ov := ob.MakeView()
 	ov.Match()
 	tickPrec := 3
-	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), tickPrec, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), tickPrec, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	basePrice, found := types.OrderBookBasePrice(ov, tickPrec)
 	if !found {
 		panic("base price not found")
@@ -188,7 +200,10 @@ func ExampleMakeOrderBookPairResponse_zigzag() {
 	ov.Match()
 
 	basePrice, _ := types.OrderBookBasePrice(ov, 4)
-	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, 20)
+	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    20,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], basePrice)
 
 	// Output:
@@ -217,7 +232,10 @@ func ExampleMakeOrderBookPairResponse_edgecase1() {
 	ov.Match()
 
 	basePrice, _ := types.OrderBookBasePrice(ov, 4)
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 3, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 3, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], basePrice)
 
 	// Output:
@@ -260,7 +278,10 @@ func ExampleMakeOrderBookPairResponse_edgecase2() {
 	ov := ob.MakeView()
 	ov.Match()
 
-	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 
 	// Output:
@@ -283,7 +304,10 @@ func ExampleMakeOrderBookPairResponse_edgecase3() {
 	ov := ob.MakeView()
 	ov.Match()
 
-	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, utils.ParseDec("0.9"), utils.ParseDec("1.1"), 3, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    10,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 
 	// Output:
@@ -307,7 +331,20 @@ func ExampleMakeOrderBookPairResponse_priceUnits1() {
 	ov := ob.MakeView()
 	ov.Match()
 
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4,
+		types.OrderBookConfig{
+			PriceUnitPower: 0,
+			MaxNumTicks:    10,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 1,
+			MaxNumTicks:    10,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 2,
+			MaxNumTicks:    10,
+		},
+	)
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 	types.PrintOrderBookResponse(resp.OrderBooks[1], resp.BasePrice)
 	types.PrintOrderBookResponse(resp.OrderBooks[2], resp.BasePrice)
@@ -401,7 +438,20 @@ func ExampleMakeOrderBookPairResponse_priceUnits2() {
 	ov := ob.MakeView()
 	ov.Match()
 
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4, 10)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4,
+		types.OrderBookConfig{
+			PriceUnitPower: 0,
+			MaxNumTicks:    10,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 1,
+			MaxNumTicks:    10,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 2,
+			MaxNumTicks:    10,
+		},
+	)
 	types.PrintOrderBookResponse(resp.OrderBooks[0], resp.BasePrice)
 	types.PrintOrderBookResponse(resp.OrderBooks[1], resp.BasePrice)
 	types.PrintOrderBookResponse(resp.OrderBooks[2], resp.BasePrice)

--- a/x/liquidity/types/orderbook_test.go
+++ b/x/liquidity/types/orderbook_test.go
@@ -30,7 +30,10 @@ func TestMakeOrderBookResponse(t *testing.T) {
 		panic("base price not found")
 	}
 
-	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4, 20)
+	resp := types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4, types.OrderBookConfig{
+		PriceUnitPower: 0,
+		MaxNumTicks:    20,
+	})
 	types.PrintOrderBookResponse(resp.OrderBooks[0], basePrice)
 }
 
@@ -67,5 +70,18 @@ func makeOrderBookPairResponse(numOrders, numPools, numTicks, tickPrec int) type
 	ov := ob.MakeView()
 	ov.Match()
 
-	return types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4, numTicks)
+	return types.MakeOrderBookPairResponse(1, ov, lowestPrice, highestPrice, 4,
+		types.OrderBookConfig{
+			PriceUnitPower: 0,
+			MaxNumTicks:    numTicks,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 1,
+			MaxNumTicks:    numTicks,
+		},
+		types.OrderBookConfig{
+			PriceUnitPower: 2,
+			MaxNumTicks:    numTicks,
+		},
+	)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Make `MakeOrderBookPairResponse` to accept `OrderBookConfig` which is used to configure the order book responses.
It consists of two fields, `PriceUnitPower` and `MaxNumTicks`.

## Tasks

- [x] Refactor `MakeOrderBookPairResponse`

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
