### PR TITLE
feat: add MM order cli commands and update api docs

### DIFF
--- a/docs/cli/liquidity.md
+++ b/docs/cli/liquidity.md
@@ -21,8 +21,10 @@ Note that [jq](https://stedolan.github.io/jq/) is recommended to be installed as
     * [Withdraw](#Withdraw)
     * [LimitOrder](#LimitOrder)
     * [MarketOrder](#MarketOrder)
+    * [MMOrder](#MMOrder)
     * [CancelOrder](#CancelOrder)
     * [CancelAllOrders](#CancelAllOrders)
+    * [CancelMMOrder](#CancelMMOrder)
 - [Query](#Query)
     * [Params](#Params)
     * [Pairs](#Pairs)
@@ -348,6 +350,57 @@ squad tx liquidity market-order 1 sell 100000000uatom uusd 100000000 \
 squad q liquidity orders cosmos1zaavvzxez0elundtn32qnk9lkm8kmcszzsv80v -o json | jq
 ```
 
+## MMOrder
+
+Make an MM(market making) order.
+An MM order is a group of multiple buy/sell limit orders which are distributed
+evenly based on its parameters.
+
+Usage
+
+```bash
+mm-order [pair-id] [max-sell-price] [min-sell-price] [sell-amount] [max-buy-price] [min-buy-price] [buy-amount]
+```
+
+| **Argument**   | **Description**              |
+|:---------------|:-----------------------------|
+| pair-id        | pair id                      |
+| max-sell-price | maximum price of sell orders |
+| min-sell-price | minimum price of sell orders |
+| sell-amount    | total amount of sell orders  |
+| max-buy-price  | maximum price of buy orders  |
+| min-buy-price  | minimum price of buy orders  |
+| buy-amount     | total amount of buy orders   |
+
+| **Optional Flag** | **Description**                                                                                                                                         |
+|:------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| order-lifespan    | duration that the order lives until it is expired; an order will be executed for at least one batch, even if the lifespan is 0; valid time units are ns |us|ms|s|m|h|
+
+Example
+
+```bash
+# Make a market making order in pair 1 with following parameters:
+# Sell: total 1000000 with price range from 102 to 101
+# Buy: total 1000000 with price range from 100 to 99
+squad tx liquidity mm-order 1 102 101 1000000 100 99 1000000  \
+--chain-id localnet \
+--from alice \
+--keyring-backend test \
+--broadcast-mode block \
+--yes \
+--output json | jq
+
+# Make the same order with order-lifespan flag
+squad tx liquidity mm-order 1 102 101 1000000 100 99 1000000  \
+--order-lifespan 30s \
+--chain-id localnet \
+--from alice \
+--keyring-backend test \
+--broadcast-mode block \
+--yes \
+--output json | jq
+```
+
 ## CancelOrder
 
 Cancel an order.
@@ -396,6 +449,33 @@ Example
 
 ```bash
 squad tx liquidity cancel-all-orders 1,2,3 \
+--chain-id localnet \
+--from alice \
+--keyring-backend=test \
+--broadcast-mode block \
+--yes \
+--output json | jq
+```
+
+## CancelMMOrder
+
+Cancel a market making order in a pair.
+This will cancel all limit orders in the pair made by the mm order.
+
+Usage
+
+```bash
+cancel-mm-order [pair-id]
+```
+
+| **Argument** | **Description** |
+|:-------------|:----------------|
+| pair-id      | pair id         |
+
+Example
+
+```bash
+squad tx liquidity cancel-mm-order 1 \
 --chain-id localnet \
 --from alice \
 --keyring-backend=test \
@@ -626,5 +706,3 @@ squad order-books 1 --num-ticks=10
 
 squad order-books 1,2,3
 ```
-
-

--- a/x/farming/spec/01_concepts.md
+++ b/x/farming/spec/01_concepts.md
@@ -48,7 +48,7 @@ In the farming module, farming rewards are calculated per epoch based on the dis
 
 To calculate the rewards for a single farmer, take the total rewards for the epoch before the staking started, minus the current total rewards. 
 
-The farming module takes references from [F1 Fee Distribution](https://github.com/cosmos/cosmos-sdk/blob/master/docs/spec/fee_distribution/f1_fee_distr.pdf) that is used in the Cosmos SDK [x/distribution](https://github.com/cosmos/cosmos-sdk/blob/master/x/distribution/spec/01_concepts.md) module.
+The farming module takes references from [F1 Fee Distribution](https://github.com/cosmos/cosmos-sdk/blob/master/docs/spec/fee_distribution/f1_fee_distr.pdf) that is used in the Cosmos SDK [x/distribution](https://github.com/cosmos/cosmos-sdk/blob/v0.45.3/x/distribution/spec/01_concepts.md) module.
 
 ### Accumulated Unit Reward 
 

--- a/x/farming/spec/04_messages.md
+++ b/x/farming/spec/04_messages.md
@@ -72,7 +72,7 @@ type MsgStake struct {
 
 A farmer must have some staking coins to trigger this message.
 
-In contrast to the Cosmos SDK [staking](https://github.com/cosmos/cosmos-sdk/blob/master/x/staking/spec/01_state.md) module, there is no concept of an unbonding period where some time is required to unstake coins. 
+In contrast to the Cosmos SDK [staking](https://github.com/cosmos/cosmos-sdk/blob/v0.45.3/x/staking/spec/01_state.md) module, there is no concept of an unbonding period where some time is required to unstake coins.
 
 All of the accumulated farming rewards are automatically withdrawn to the farmer after an unstaking event is triggered.
 
@@ -86,7 +86,7 @@ type MsgUnstake struct {
 ## MsgHarvest
 
 The farming rewards are automatically accumulated, but they are not automatically distributed. 
-A farmer must harvest their farming rewards. This mechanism is similar to the Cosmos SDK [distribution](https://github.com/cosmos/cosmos-sdk/blob/master/x/distribution/spec/01_concepts.md) module.
+A farmer must harvest their farming rewards. This mechanism is similar to the Cosmos SDK [distribution](https://github.com/cosmos/cosmos-sdk/blob/v0.45.3/x/distribution/spec/01_concepts.md) module.
 Also, if there is `UnharvestedRewards`, unharvested rewards are also withdrawn and the object is deleted.
 
 ```go


### PR DESCRIPTION
## Description

This PR adds missing cli command implementations and related docs.

## Tasks

- [x] Add `mm-order` and `cancel-mm-order` tx commands
- [x] Update API docs

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
