### PR TITLE
fix: reject same base/quote coin denom in `MsgCreatePair`

### DIFF
--- a/x/liquidity/client/cli/query.go
+++ b/x/liquidity/client/cli/query.go
@@ -657,7 +657,7 @@ $ %s query %s order 1 1
 func NewQueryOrderBooksCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "order-books [pair-ids]",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		Short: "Query order books",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Query order books of specified pairs.

--- a/x/liquidity/types/msgs.go
+++ b/x/liquidity/types/msgs.go
@@ -61,6 +61,9 @@ func (msg MsgCreatePair) ValidateBasic() error {
 	if err := sdk.ValidateDenom(msg.QuoteCoinDenom); err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
+	if msg.BaseCoinDenom == msg.QuoteCoinDenom {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "cannot use same denom for both base coin and quote coin")
+	}
 	return nil
 }
 

--- a/x/liquidity/types/msgs_test.go
+++ b/x/liquidity/types/msgs_test.go
@@ -45,6 +45,13 @@ func TestMsgCreatePair(t *testing.T) {
 			},
 			"invalid denom: invaliddenom!: invalid request",
 		},
+		{
+			"same denom",
+			func(msg *types.MsgCreatePair) {
+				msg.QuoteCoinDenom = "denom1"
+			},
+			"cannot use same denom for both base coin and quote coin: invalid request",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			msg := types.NewMsgCreatePair(testAddr, "denom1", "denom2")


### PR DESCRIPTION
## Description

This PR fixes two bugs in the liquidity module.

closes: #363 

## Tasks

- [x] Correct number of arguments in `NewQueryOrderBooksCmd` (`2` -> `1`)
- [x] Reject using same denom for both base/quote coin in `MsgCreatePair`