### PR TITLE
fix: check if farmer exists when allocating rewards to target denom

### DIFF
--- a/x/farm/keeper/plan.go
+++ b/x/farm/keeper/plan.go
@@ -212,7 +212,10 @@ func (k Keeper) AllocateRewards(ctx sdk.Context) error {
 
 	sort.Strings(denomsWithRewards)
 	for _, denom := range denomsWithRewards {
-		farm, _ := ck.getFarm(ctx, denom)
+		farm, found := ck.getFarm(ctx, denom)
+		if !found { // Sanity check
+			panic("farm not found")
+		}
 		farm.CurrentRewards = farm.CurrentRewards.Add(rewardsByDenom[denom]...)
 		farm.OutstandingRewards = farm.OutstandingRewards.Add(rewardsByDenom[denom]...)
 		k.SetFarm(ctx, denom, farm)

--- a/x/farm/keeper/plan_test.go
+++ b/x/farm/keeper/plan_test.go
@@ -65,6 +65,7 @@ func (s *KeeperTestSuite) TestAllocateRewards_NoFarmer() {
 	s.createPairWithLastPrice("denom1", "denom2", sdk.NewDec(1))
 	plan := s.createPrivatePlan([]types.RewardAllocation{
 		types.NewPairRewardAllocation(1, utils.ParseCoins("100_000000stake")),
+		types.NewDenomRewardAllocation("pool1", utils.ParseCoins("100_000000stake")),
 	}, utils.ParseCoins("10000_000000stake"))
 
 	s.nextBlock()

--- a/x/farm/keeper/util.go
+++ b/x/farm/keeper/util.go
@@ -135,6 +135,10 @@ func (ra *rewardAllocator) allocateRewardsToPair(farmingPoolAddr sdk.AccAddress,
 }
 
 func (ra *rewardAllocator) allocateRewardsToDenom(farmingPoolAddr sdk.AccAddress, denom string, rewards sdk.Coins) {
+	farm, found := ra.ck.getFarm(ra.ctx, denom)
+	if !found || !farm.TotalFarmingAmount.IsPositive() {
+		return
+	}
 	farmingPool := farmingPoolAddr.String()
 	rewardsByDenom, ok := ra.allocatedRewards[farmingPool]
 	if !ok {


### PR DESCRIPTION
## Description

There was no such check for `DenomRewardAllocation` which causes an invalid `Farm` to be created when allocating rewards

## Tasks

- [x] Fix bug
- [x] Write test

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/v0.45.9/docs/building-modules/README.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
